### PR TITLE
Fixing Windows issue with sequelize db:migrate command

### DIFF
--- a/backend/db/config.ts
+++ b/backend/db/config.ts
@@ -1,3 +1,3 @@
-import config from '../config';
+import { default as config } from '../config';
 
 module.exports = config.database;

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,7 +19,7 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "sequelize": "ts-node node_modules/.bin/sequelize"
+    "sequelize": "ts-node node_modules/sequelize-cli/lib/sequelize"
   },
   "dependencies": {
     "@nestjs/common": "^7.0.0",


### PR DESCRIPTION
sequelize db:migrate was not able to run - fix in package.json
once fixed, there was issue with import of default export for db